### PR TITLE
21 create post api endpoint to upload pothole images

### DIFF
--- a/drizzle/schema.sql
+++ b/drizzle/schema.sql
@@ -59,7 +59,7 @@ INSERT INTO "paths" (id, rover_id, route, timestamp) VALUES
     (2, 2, ST_GeomFromText('LINESTRING(-118.2437 34.0522, -118.2440 34.0515, -118.2443 34.0510)', 4326), NOW());
 
 -- Insert sample potholes with POINT (single location)
-INSERT INTO "potholes" (id, path_id, location, severity, image_url) VALUES
-    (1, 1, ST_GeomFromText('POINT(-73.9855 40.7485)', 4326), 3, 'https://example.com/pothole1.jpg'),
-    (2, 1, ST_GeomFromText('POINT(-73.9854 40.7486)', 4326), 5, 'https://example.com/pothole2.jpg'),
-    (3, 2, ST_GeomFromText('POINT(-118.2438 34.0520)', 4326), 2, 'https://example.com/pothole3.jpg');
+-- INSERT INTO "potholes" (id, path_id, location, severity, image_url) VALUES
+    -- (1, 1, ST_GeomFromText('POINT(-73.9855 40.7485)', 4326), 3, 'https://example.com/pothole1.jpg'),
+    -- (2, 1, ST_GeomFromText('POINT(-73.9854 40.7486)', 4326), 5, 'https://example.com/pothole2.jpg'),
+    -- (3, 2, ST_GeomFromText('POINT(-118.2438 34.0520)', 4326), 2, 'https://example.com/pothole3.jpg');

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -9,7 +9,6 @@ import {
 	geometry,
 	index,
   } from "drizzle-orm/pg-core";
-  import { sql } from "drizzle-orm";
   
   // User Authentication
   export const user = pgTable("user", {

--- a/src/routes/api/potholes/+server.ts
+++ b/src/routes/api/potholes/+server.ts
@@ -1,0 +1,47 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { db } from "$lib/server/db";
+import { potholes } from "$lib/server/db/schema";
+import { sql } from "drizzle-orm";
+import fs from 'fs';
+import path from 'path';
+
+export const POST: RequestHandler = async ({ request }) => {
+    try {
+        const formData = await request.formData();
+
+        const pathId = parseInt(formData.get('pathId') as string);
+        const latitude = parseFloat(formData.get('latitude') as string);
+        const longitude = parseFloat(formData.get('longitude') as string);
+        const severity = parseInt(formData.get('severity') as string);
+        const file = formData.get('image') as File;
+
+        if (!pathId || !latitude || !longitude || !severity || !file) {
+            return new Response(JSON.stringify({ error: 'Missing required fields' }), { status: 400 });
+        }
+
+        // Ensure uploads directory exists
+        const uploadDir = path.join(process.cwd(), 'uploads');
+        if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+        // Save the uploaded file
+        const filePath = path.join(uploadDir, file.name);
+        const buffer = Buffer.from(await file.arrayBuffer());
+        fs.writeFileSync(filePath, buffer);
+
+        // Insert into database
+        const result = await db
+            .insert(potholes)
+            .values({
+                pathId,
+                location: sql`ST_SetSRID(ST_MakePoint(${longitude}, ${latitude}), 4326)`,
+                severity,
+                imageUrl: filePath
+            })
+            .returning();
+
+        return new Response(JSON.stringify(result[0]), { status: 201, headers: { "Content-Type": "application/json" } });
+    } catch (err) {
+        console.error("Error inserting pothole:", err);
+        return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+    }
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,7 +11,11 @@ const config = {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter(),
+		// TODO: fix csrf issue with POST requests
+		// csrf: {
+		// 	checkOrigin: false,
+		// }
 	}
 };
 


### PR DESCRIPTION
You can send POST requests to the `/api/potholes` endpoint to save images to `uploads/` within the folder where node is running.

Example:
`curl -X POST http://127.0.0.1:5173/api/potholes   -F "image=@<path>"   -F "pathId=1"   -F "latitude=45.4215"   -F "longitude=-75.6972"   -F "severity=2"`

Bug:
`cross site post form submissions are forbidden`, csrf has been disabled as a workaround, but it needs to be fixed for security purposes.